### PR TITLE
Fix collector attribute typing to restore TypeScript build

### DIFF
--- a/api/src/types.ts
+++ b/api/src/types.ts
@@ -7,7 +7,7 @@ export type LiveAnnounce = {
   prefix: string;
   origin_as: number | null;
   as_path?: string;
-  next_hop?: string;
+  next_hop?: string | null;
 };
 
 export type LiveWithdraw = {


### PR DESCRIPTION
## Summary
- introduce a typed attribute helper in the collector to safely extract origin, AS paths, and next hops
- allow null next-hop values in LiveAnnounce so websocket payloads match collector outputs

## Testing
- npm test (api)
- npm run lint (api)
- npm run build (api)
- npm test (web)
- npm run build (web)

------
https://chatgpt.com/codex/tasks/task_e_68f16d5c3ff48320a466af1b797391e7