### PR TITLE
Ensure Sigma nodes have initial positions

### DIFF
--- a/src/components/SigmaGraph.tsx
+++ b/src/components/SigmaGraph.tsx
@@ -121,6 +121,8 @@ export function SigmaGraph({ nodes, links, className }: SigmaGraphProps): JSX.El
         count: node.count,
         size,
         color: NODE_COLORS[node.type],
+        x: 0,
+        y: 0,
       });
     }
 


### PR DESCRIPTION
## Summary
- ensure each sigma graph node starts with numeric x/y coordinates so the renderer always has valid positions

## Testing
- npm test *(fails: Missing tailwindcss module in PostCSS config)*

------
https://chatgpt.com/codex/tasks/task_e_68f1fde536048320ae277dd95a4ca265