### PR TITLE
Handle worker initialization failures and clarify temporary storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TopoLens
 
-TopoLens is now a static web application built with [Vite](https://vitejs.dev/) that visualises live BGP activity using the [RIPE RIS Live](https://ris-live.ripe.net/) WebSocket feed. The browser stores every update locally in IndexedDB so you can reconnect or refresh without losing the most recent announcements.
+TopoLens is now a static web application built with [Vite](https://vitejs.dev/) that visualises live BGP activity using the [RIPE RIS Live](https://ris-live.ripe.net/) WebSocket feed. The browser keeps a rolling in-memory list of the most recent announcements for quick exploration during your session.
 
 ## Getting started
 
@@ -22,7 +22,7 @@ npm run preview
 
 * A WebSocket connection is opened to `wss://ris-live.ripe.net/v1/ws/` and the app subscribes to the `rrc00.ripe.net` stream.
 * Incoming messages are normalised into announcement and withdrawal records.
-* Updates are persisted in IndexedDB so that the most recent entries remain available between refreshes.
+* A rolling in-memory buffer keeps the most recent entries available while the page remains open.
 * The UI presents the latest events with key metadata such as AS path, peer, origin AS, and next hop when available.
 
 ## Testing

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -278,7 +278,11 @@ export default function App(): JSX.Element {
     [filterMatcher, updates],
   );
 
-  const { graph: graphData, isComputing: isGraphComputing } = useGraphData(filteredUpdates);
+  const {
+    graph: graphData,
+    isComputing: isGraphComputing,
+    error: graphError,
+  } = useGraphData(filteredUpdates);
 
   const activeFilterCount = useMemo(() => {
     let count = 0;
@@ -368,7 +372,7 @@ export default function App(): JSX.Element {
                 <div>
                   <CardTitle className="text-3xl text-white">TopoLens</CardTitle>
                   <CardDescription className="max-w-xl text-base text-slate-300">
-                    Observe global BGP relationships in near real-time through a mystic violet lens. Parsed updates are persisted locally for replay and deeper exploration.
+                    Observe global BGP relationships in near real-time through a mystic violet lens. Recent updates stay in memory for quick exploration during your session.
                   </CardDescription>
                 </div>
                 {error && <p className="text-sm text-rose-300">{error}</p>}
@@ -394,7 +398,7 @@ export default function App(): JSX.Element {
                   Reconnect
                 </Button>
                 <Button variant="ghost" onClick={clearHistory}>
-                  Clear stored updates
+                  Clear recent updates
                 </Button>
               </div>
             </CardHeader>
@@ -408,6 +412,7 @@ export default function App(): JSX.Element {
                 <CardDescription className="text-slate-300/80">
                   {filteredUpdates.length} visible update{filteredUpdates.length === 1 ? "" : "s"}
                 </CardDescription>
+                {graphError && <p className="text-sm text-rose-300">{graphError}</p>}
               </div>
               <div className="flex flex-col items-start gap-2 text-xs text-slate-300/70 md:items-end">
                 {isGraphComputing && (
@@ -460,7 +465,7 @@ export default function App(): JSX.Element {
               <p className="text-xs text-slate-300/80">
                 {filteredUpdates.length === 0
                   ? "No updates match the current filters."
-                  : "Latest persisted BGP events"}
+                  : "Latest captured BGP events"}
               </p>
             </div>
             <Button variant="ghost" size="sm" onClick={() => setIsLogsOpen(false)}>
@@ -477,7 +482,7 @@ export default function App(): JSX.Element {
                 {filteredUpdates.map((update) => (
                   <UpdateRow
                     update={update}
-                    key={update.id ?? `${update.prefix}-${update.timestamp}-${update.kind}`}
+                    key={`${update.prefix}-${update.timestamp}-${update.kind}`}
                   />
                 ))}
               </ul>

--- a/src/components/SigmaGraph.tsx
+++ b/src/components/SigmaGraph.tsx
@@ -117,7 +117,7 @@ export function SigmaGraph({ nodes, links, className }: SigmaGraphProps): JSX.El
       const size = 6 + Math.log1p(node.count) * 2;
       graph.addNode(node.id, {
         label: node.label,
-        type: node.type,
+        category: node.type,
         count: node.count,
         size,
         color: NODE_COLORS[node.type],


### PR DESCRIPTION
## Summary
- guard both RIPE RIS and graph workers with capability checks, error listeners, and clearer status handling so failures surface in the UI
- adjust Sigma graph node attributes and app copy to remove the false persistence promise and better describe in-memory updates
- update the README to reflect the in-memory buffer instead of IndexedDB persistence

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f1ff4b447c8320a0bb267ad21afcb4